### PR TITLE
automatically find new/deleted ruby scripts in /usr/bin, /usr/sbin

### DIFF
--- a/bin/rbenv-alternatives
+++ b/bin/rbenv-alternatives
@@ -34,11 +34,25 @@ while read command; do
         mkdir -p "${RBENV_ROOT}/versions/$version/bin"
         ln -s "$master" "${RBENV_ROOT}/versions/$version/bin/ruby"
         ln -s "${master/ruby/gem}" "${RBENV_ROOT}/versions/$version/bin/gem"
-        for cmd in /usr/bin/rake /usr/bin/bundle /usr/bin/pry; do
-          [ -x $cmd ] && ln -s $cmd "${RBENV_ROOT}/versions/$version/bin/${cmd##*/}"
-        done
         echo "Added $version"
       fi
+      ## find deleted ruby scripts, then delete symlink
+      find ${RBENV_ROOT}/versions/$version/bin -type l | while read cmd; do
+        if [ ! -x `readlink $cmd` ]; then
+          echo "delete dangling symlink: ${cmd##*/}"
+          rm $cmd
+        fi
+      done
+      ## find new ruby scripts, then create symlink
+      find /usr/bin /usr/sbin -maxdepth 1 -type f -a -executable | while read cmd; do
+        if head -1 $cmd | grep '/usr/bin/env ruby' 1>/dev/null 2>/dev/null; then
+          dst=${RBENV_ROOT}/versions/$version/bin/${cmd##*/}
+          if [ ! -L ${dst} ]; then
+            echo "found new command ${cmd}"
+            ln -s $cmd $dst
+          fi
+        fi
+      done
       ;;
     *)
       if [ "$skip" = 'false' ]; then

--- a/bin/rbenv-alternatives
+++ b/bin/rbenv-alternatives
@@ -34,7 +34,9 @@ while read command; do
         mkdir -p "${RBENV_ROOT}/versions/$version/bin"
         ln -s "$master" "${RBENV_ROOT}/versions/$version/bin/ruby"
         ln -s "${master/ruby/gem}" "${RBENV_ROOT}/versions/$version/bin/gem"
-        [ -x /usr/bin/rake ] && ln -s /usr/bin/rake "${RBENV_ROOT}/versions/$version/bin/rake"
+        for cmd in /usr/bin/rake /usr/bin/bundle /usr/bin/pry; do
+          [ -x $cmd ] && ln -s $cmd "${RBENV_ROOT}/versions/$version/bin/${cmd##*/}"
+        done
         echo "Added $version"
       fi
       ;;


### PR DESCRIPTION
support ruby scripts installed by debian packages. (/usr/bin/bundle, /usr/bin/pry, etc...)

---

Current rbenv-alternatives has a problem with RBENV_VERSION and command execution.

I install ruby 1.9.3, 2.0.0 using debian package, and install ruby 2.1.0 using ruby-build.

```
$ sudo apt-get install ruby1.9.3 ruby2.0.0
$ rbenv install 2.1.0-p0
$ rbenv alternatives
$ rbenv versions
* system (set by /home/tsuyoshi/.rbenv/version)
  1.9.3-debian
  2.0.0-debian
  2.1.0-p0
```

And install bundler, pry with debian package (for 1.9.3, 2.0.0) / with gem install (2.1.0)

```
$ sudo apt-get install bundler pry
$ RBENV_VERSION=2.1.0-p0 gem install bundler pry
$ rbenv rehash
```

bundle command, pry command works with ruby 1.9.3:

```
$ bundle env
Bundler 1.5.2
Ruby 1.9.3 (2013-11-22 patchlevel 484) [x86_64-linux]
Rubygems 1.8.23
GEM_HOME 


Gemfile
<No Gemfile found>


Gemfile.lock
<No Gemfile.lock found>
$ pry
[1] pry(main)> RUBY_VERSION
=> "1.9.3"
[2] pry(main)> 
```

Using RBENV_VERSION=2.1.0-p0 works fine.

```
$ RBENV_VERSION=2.1.0-p0 bundle env
Bundler 1.5.2
Ruby 2.1.0 (2013-12-25 patchlevel 0) [x86_64-linux]
Rubygems 2.2.0
GEM_HOME 


Gemfile
<No Gemfile found>


Gemfile.lock
<No Gemfile.lock found>
$ RBENV_VERSION=2.1.0-p0 pry
[1] pry(main)> RUBY_VERSION
=> "2.1.0"
[2] pry(main)> 
```

But, bundle command, pry command with RBENV_VERSION=1.9.3-debian, RBENV_VERSION=2.0.0-debian **does not work**.

```
$ RBENV_VERSION=2.0.0-debian bundle env
rbenv: bundle: command not found

The `bundle' command exists in these Ruby versions:
  2.1.0-p0

$ RBENV_VERSION=2.0.0-debian pry
rbenv: pry: command not found

The `pry' command exists in these Ruby versions:
  2.1.0-p0

$ RBENV_VERSION=1.9.3-debian bundle env
rbenv: bundle: command not found

The `bundle' command exists in these Ruby versions:
  2.1.0-p0

$ RBENV_VERSION=1.9.3-debian pry
rbenv: pry: command not found

The `pry' command exists in these Ruby versions:
  2.1.0-p0

```

On the other hand, rake command works with any RBENV_VERSION.

```
$ echo "task :default do p RUBY_VERSION; end" > Rakefile
$ rake 
"1.9.3"
$ RBENV_VERSION=1.9.3-debian rake
"1.9.3"
$ RBENV_VERSION=2.0.0-debian rake
"2.0.0"
$ RBENV_VERSION=2.1.0-p0 rake
"2.1.0"
```

This is beacause `rbenv alternatives` creates symlink .rbenv/versions/1.9.3-debian/bin/rake,
.rbenv/versions/2.0.0-debian/bin/rake.

```
$ find .rbenv/versions/ -path '*/bin/rake' -ls
165651    0 lrwxrwxrwx   1 tsuyoshi tsuyoshi       13  1月 26 00:46 .rbenv/versions/1.9.3-debian/bin/rake -> /usr/bin/rake
684572    0 lrwxrwxrwx   1 tsuyoshi tsuyoshi       13  1月 26 00:41 .rbenv/versions/2.0.0-debian/bin/rake -> /usr/bin/rake
556777    4 -rwxr-xr-x   1 tsuyoshi tsuyoshi     1244 10月 12 06:35 .rbenv/versions/2.1.0-p0/lib/ruby/gems/2.1.0/gems/rake-10.1.0/bin/rake
954205    4 -rwxr-xr-x   1 tsuyoshi tsuyoshi     1244  1月 26 00:44 .rbenv/versions/2.1.0-p0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/bin/rake
429852    4 -rwxr-xr-x   1 tsuyoshi tsuyoshi      481  1月 26 00:44 .rbenv/versions/2.1.0-p0/bin/rake
```

So, this problem is solved by creating symlinks as follows:

```
$ ln -s /usr/bin/bundle /usr/bin/pry .rbenv/versions/1.9.3-debian/bin/
$ ln -s /usr/bin/bundle /usr/bin/pry .rbenv/versions/2.0.0-debian/bin/
$ RBENV_VERSION=1.9.3-debian bundle env
Bundler 1.5.2
Ruby 1.9.3 (2013-11-22 patchlevel 484) [x86_64-linux]
Rubygems 1.8.23
GEM_HOME 


Gemfile
<No Gemfile found>


Gemfile.lock
<No Gemfile.lock found>
$ RBENV_VERSION=1.9.3-debian pry
[1] pry(main)> RUBY_VERSION
=> "1.9.3"
[2] pry(main)> 
$ RBENV_VERSION=2.0.0-debian bundle env
Bundler 1.5.2
Ruby 2.0.0 (2013-11-22 patchlevel 353) [x86_64-linux-gnu]
Rubygems 2.0.14
GEM_HOME 


Gemfile
<No Gemfile found>


Gemfile.lock
<No Gemfile.lock found>
$ RBENV_VERSION=2.0.0-debian pry
[1] pry(main)> RUBY_VERSION
=> "2.0.0"
[2] pry(main)> 
```

---

This pull request makes `rbenv alternatives` automatically find ruby scripts in /usr/bin, /bin directories
and creates symlinks.

```
$ cd .rbenv/plugins/rbenv-alternatives
$ git remote add fork https://github.com/minimum2scp/rbenv-alternatives.git
$ git remote update
$ git checkout fork/support-more-commands
$ rbenv alternatives
$ rbenv alternatives
Skipping 1.9.3-debian, it already exists
found new command /usr/bin/thor
found new command /usr/bin/bundle
found new command /usr/bin/bundle_ruby
found new command /usr/bin/pry
found new command /usr/bin/bundler
Skipping 2.0.0-debian, it already exists
found new command /usr/bin/thor
found new command /usr/bin/bundle
found new command /usr/bin/bundle_ruby
found new command /usr/bin/pry
found new command /usr/bin/bundler
$ find .rbenv/versions \( -path '*/bin/bundle' -o -path '*/bin/pry' \) -a -type l -ls
162552    0 lrwxrwxrwx   1 tsuyoshi tsuyoshi       15  1月 26 01:33 .rbenv/versions/1.9.3-debian/bin/bundle -> /usr/bin/bundle
162554    0 lrwxrwxrwx   1 tsuyoshi tsuyoshi       12  1月 26 01:33 .rbenv/versions/1.9.3-debian/bin/pry -> /usr/bin/pry
162557    0 lrwxrwxrwx   1 tsuyoshi tsuyoshi       15  1月 26 01:33 .rbenv/versions/2.0.0-debian/bin/bundle -> /usr/bin/bundle
165396    0 lrwxrwxrwx   1 tsuyoshi tsuyoshi       12  1月 26 01:33 .rbenv/versions/2.0.0-debian/bin/pry -> /usr/bin/pry
```

And delete dangling symlinks.

```
$ sudo apt-get remove pry
$ rbenv alternatives
Skipping 1.9.3-debian, it already exists
delete dangling symlink: pry
Skipping 2.0.0-debian, it already exists
delete dangling symlink: pry
$ find .rbenv/versions \( -path '*/bin/bundle' -o -path '*/bin/pry' \) -a -type l -ls
162552    0 lrwxrwxrwx   1 tsuyoshi tsuyoshi       15  1月 26 01:33 .rbenv/versions/1.9.3-debian/bin/bundle -> /usr/bin/bundle
162557    0 lrwxrwxrwx   1 tsuyoshi tsuyoshi       15  1月 26 01:33 .rbenv/versions/2.0.0-debian/bin/bundle -> /usr/bin/bundle
```
