### PR TITLE
Add --overwrite option

### DIFF
--- a/bin/rbenv-alternatives
+++ b/bin/rbenv-alternatives
@@ -3,7 +3,7 @@ set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
 if [ "$1" == '--version' ]; then
-  echo '0.3.0'
+  echo '0.4.0-dev'
   exit 0
 fi
 
@@ -25,13 +25,14 @@ while read command; do
     master*)
       master=$(echo "$command" | awk '{print $2}')
       version=$($master -e 'puts(((defined?(RUBY_ENGINE) && RUBY_ENGINE != "ruby") && RUBY_ENGINE + "-" || "") + (defined?(Rubinius) && Rubinius::VERSION || (defined?(JRUBY_VERSION) && JRUBY_VERSION) || RUBY_VERSION))')-debian
-      if [ -d "${RBENV_ROOT}/versions/$version" ]; then
+      if [ -e "${RBENV_ROOT}/versions/$version/is-debian-alternative" ]; then
         skip=true
         echo "Skipping $version, it already exists"
       else
         skip=false
         rm -rf "${RBENV_ROOT}/versions/$version"
         mkdir -p "${RBENV_ROOT}/versions/$version/bin"
+        echo "$(basename $master)" > "${RBENV_ROOT}/versions/$version/is-debian-alternative"
         ln -s "$master" "${RBENV_ROOT}/versions/$version/bin/ruby"
         ln -s "${master/ruby/gem}" "${RBENV_ROOT}/versions/$version/bin/gem"
         [ -x /usr/bin/rake ] && ln -s /usr/bin/rake "${RBENV_ROOT}/versions/$version/bin/rake"

--- a/bin/rbenv-alternatives
+++ b/bin/rbenv-alternatives
@@ -7,6 +7,16 @@ if [ "$1" == '--version' ]; then
   exit 0
 fi
 
+# if this option is passed, overwrite existing verions with a symlink to
+# similarly-versioned debian alternatives.
+#
+# eg, if we create an alternative "2.1.8-debian", also link "2.1.8" -> "2.1.8-debian".
+# If 2.1.8 already existed, it is deleted.
+overwrite=''
+if [ "$1" == '--overwrite' ]; then
+  overwrite='true'
+fi
+
 if ! which update-alternatives >/dev/null; then
   echo "Sorry, it seems like you do not have update-alternatives available on your PATH."
   echo "Are you sure this is a Debian (or derivative) system?"
@@ -37,6 +47,12 @@ while read command; do
         ln -s "${master/ruby/gem}" "${RBENV_ROOT}/versions/$version/bin/gem"
         [ -x /usr/bin/rake ] && ln -s /usr/bin/rake "${RBENV_ROOT}/versions/$version/bin/rake"
         echo "Added $version"
+        if [ "$overwrite" = 'true' ]; then
+          normal_version="${version%-debian}"
+          rm -rf "${RBENV_ROOT}/versions/$normal_version"
+          ln -s "$version" "${RBENV_ROOT}/versions/$normal_version"
+          echo "overwrote $normal_version with $version"
+        fi
       fi
       ;;
     *)

--- a/etc/rbenv.d/exec/alternatives-gems.bash
+++ b/etc/rbenv.d/exec/alternatives-gems.bash
@@ -1,9 +1,7 @@
 __current_version=$(rbenv-version-name)
-case "$__current_version" in
-  *-debian)
-    export GEM_HOME="${RBENV_ROOT}/versions/${__current_version}/gems"
-    ;;
-  *)
-    true
-    ;;
-esac
+
+# we need to set GEM_HOME for debian alternatives, otherwise users need to
+# `sudo` do do gem stuff.
+if [ -e "${RBENV_ROOT}/versions/${__current_version}/is-debian-alternative" ]; then
+  export GEM_HOME="${RBENV_ROOT}/versions/${__current_version}/gems"
+fi

--- a/etc/rbenv.d/rehash/alternatives-gems.bash
+++ b/etc/rbenv.d/rehash/alternatives-gems.bash
@@ -1,11 +1,13 @@
-for version in "${RBENV_ROOT}/versions/"*-debian; do
-  version_name=$(basename "$version")
-  gem_bindir="${RBENV_ROOT}/versions/${version_name}/gems/bin"
-  version_bindir="${RBENV_ROOT}/versions/${version_name}/bin"
-  if [[ -d "$gem_bindir" ]]; then
-    for program in "$gem_bindir"/*; do
-      program_name="$(basename $program)"
-      register_shim "$program_name"
-    done
+for version in "${RBENV_ROOT}/versions/"*; do
+  if [ -e "$version/is-debian-alternative" ]; then
+    version_name=$(basename "$version")
+    gem_bindir="${RBENV_ROOT}/versions/${version_name}/gems/bin"
+    version_bindir="${RBENV_ROOT}/versions/${version_name}/bin"
+    if [[ -d "$gem_bindir" ]]; then
+      for program in "$gem_bindir"/*; do
+        program_name="$(basename $program)"
+        register_shim "$program_name"
+      done
+    fi
   fi
 done

--- a/etc/rbenv.d/which/alternatives-gems.bash
+++ b/etc/rbenv.d/which/alternatives-gems.bash
@@ -1,8 +1,6 @@
-case "$RBENV_VERSION" in
-  *-debian)
-    command_path="${RBENV_ROOT}/versions/${RBENV_VERSION}/gems/bin/${RBENV_COMMAND}"
-    if ! [ -x "$RBENV_COMMAND_PATH" ] && [ -x "$command_path" ]; then
-      RBENV_COMMAND_PATH="$command_path"
-    fi
-    ;;
-esac
+if [ -e "${RBENV_ROOT}/versions/${RBENV_VERSION}/is-debian-alternative" ]; then
+  command_path="${RBENV_ROOT}/versions/${RBENV_VERSION}/gems/bin/${RBENV_COMMAND}"
+  if ! [ -x "$RBENV_COMMAND_PATH" ] && [ -x "$command_path" ]; then
+    RBENV_COMMAND_PATH="$command_path"
+  fi
+fi


### PR DESCRIPTION
Add a --overwrite option to `rbenv alternatives` that adds a symlink from Ruby version `2.1.8` to `2.1.8-debian`. If version `2.1.8` already existed, it is deleted. This allows rbenv-alternatives users to share `.ruby-version` files with Rbenv users on other operating systems.

As an incidental change: Instead of relying on the name of a rbenv ruby version to end in "-debian", rbenv-alternatives now checks for a marker file inside the version `is-debian-alternative`. This is required to support rbenv-alternatives behavior for version symlinks craeted by the `--overwrite` option.